### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ about: Create a report to help us fix a problem with Sublime Merge
 **Version info**
 
  - OS: [e.g. macOS 10.14, Windows 10, Ubuntu 18.04]
- - Build: [e.g. 1062 - type "About" in the command palette]
+ - Build: [e.g. 2074 - type "About" in the command palette (ctrl-p)]
 
 **Description**
 


### PR DESCRIPTION
Specifying how to open the command palette might very slightly reduce friction.
Not sure it's worth mentioning that About is the very top item and the version shows up even before you 'launch' the command.