### PR TITLE
Add debug information section to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,6 +24,16 @@ Steps to reproduce the behavior:
 
 A description of what you expected to happen.
 
+**Debug Information**
+The Sublime Merge debug information can be used to narrow down the cause of an issue.
+It can be collected with the following steps:
+1. Open Sublime Merge
+2. Open the repository where the bug occurs
+3. Navigate to `Help > Debug Information` via the application menu
+4. Before sharing, please redact any information that's sensitive such as file paths, git user information, remote URLs etc.
+
+This section may be omitted/removed.
+
 **Screenshots**
 
 If applicable, add screenshots to help explain your problem. This section may be omitted/removed.


### PR DESCRIPTION
The Sublime Merge debug information is invaluable in narrowing down the cause of most issues